### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
       "Test"
    ],
    "description" : "Perl6 -- manage GNU screen sessions and use them for tests",
-   "license" : "http://www.perlfoundation.org/artistic_license_2_0",
+   "license" : "Artistic-2.0",
    "name" : "Proc::Screen",
    "perl" : "6",
    "provides" : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license